### PR TITLE
[#5] Update token count and display

### DIFF
--- a/chat_bot/index.html
+++ b/chat_bot/index.html
@@ -124,10 +124,23 @@
           xhr.onreadystatechange = function() {
               if (this.readyState === XMLHttpRequest.DONE) {
                 var errorDiv = document.getElementById("contextStatsError"); // Get the error div
+                var tokenCountSpan = document.getElementById("tokenCount");
+
                   if (this.status === 200) {
                     errorDiv.style.display = "none"; // Hide error div
                     var response = JSON.parse(this.responseText);
-                    document.getElementById("tokenCount").innerText = response.token_count.toLocaleString();
+                    var tokenCount = response.token_count;
+                    tokenCountSpan.innerText = tokenCount.toLocaleString();
+
+                    // Apply color based on token count - just a pseudo warning system of large token counts
+                    // where we may exceed the context window
+                    if (tokenCount > 1900000) {
+                        tokenCountSpan.style.color = "red";
+                    } else if (tokenCount > 1500000) {
+                        tokenCountSpan.style.color = "orange";
+                    } else {
+                        tokenCountSpan.style.color = "black"; // Default color
+                    }
                     populateFileList(response);
                   } else {
                         errorDiv.style.display = "block"; // Show error div

--- a/entrypoint.py
+++ b/entrypoint.py
@@ -350,9 +350,10 @@ def context_stats_route():
     # Extract included dirs (long term)
     # Read project files appropriately and build out context for files
     project_content = read_project_files()
+    context_message = context_prompt(project_content[0])
     # Count tokens
     try:
-        token_count = genai_model.count_tokens(project_content[0])
+        token_count = genai_model.count_tokens(context_message)
         # Return JSON with token count
         return jsonify({'status': 'OK', 'file_paths': project_content[1], 'token_count': token_count.total_tokens}), 200
     except Exception as e:


### PR DESCRIPTION
Update token count to use prompt with context instead of just the code base context.  The difference isn't huge (a few hundred tokens).

Update token count in chat bot interface to use orange/red when token counts get high.

#5 